### PR TITLE
Unpin Node minor version, use 15 instead

### DIFF
--- a/node/hello-world-javascript/airplane.yml
+++ b/node/hello-world-javascript/airplane.yml
@@ -5,7 +5,7 @@ builder: node
 builderConfig:
   entrypoint: main.js
   language: javascript
-  nodeVersion: "15.11.0"
+  nodeVersion: "15"
 
 arguments: ["--name", "{{.name}}"]
 parameters:

--- a/node/hello-world-typescript/airplane.yml
+++ b/node/hello-world-typescript/airplane.yml
@@ -5,7 +5,7 @@ builder: node
 builderConfig:
   entrypoint: main.ts
   language: typescript
-  nodeVersion: "15.11.0"
+  nodeVersion: "15"
 
 arguments: ["--name", "{{.name}}"]
 parameters:


### PR DESCRIPTION
The Airplane CLI will soon support just major version, allowing CLI to
decide on the patch version to use.
