### PR TITLE
Add slugs back to all examples

### DIFF
--- a/deno/hello-world/airplane.yml
+++ b/deno/hello-world/airplane.yml
@@ -1,5 +1,6 @@
 name: Hello World
 description: Greets you by name!
+slug: hello_world
 
 builder: deno
 builderConfig:

--- a/deno/output-list-of-numbers/airplane.yml
+++ b/deno/output-list-of-numbers/airplane.yml
@@ -1,5 +1,6 @@
 name: Number list
 description: Echos a series of numbers.
+slug: number_list
 
 builder: deno
 builderConfig:

--- a/docker/hello-world/airplane.yml
+++ b/docker/hello-world/airplane.yml
@@ -1,5 +1,6 @@
 name: Hello World
 description: Greets you by name!
+slug: hello_world
 
 builder: docker
 builderConfig:

--- a/go/hello-world/airplane.yml
+++ b/go/hello-world/airplane.yml
@@ -1,5 +1,6 @@
 name: Hello World
 description: Greets you by name!
+slug: hello_world
 
 builder: go
 builderConfig:

--- a/manual/env/airplane.yml
+++ b/manual/env/airplane.yml
@@ -1,5 +1,6 @@
 name: Print Env
 description: Logs the environment
+slug: env
 
 image: alpine:3
 command: ["env"]

--- a/manual/hello-world/airplane.yml
+++ b/manual/hello-world/airplane.yml
@@ -1,5 +1,6 @@
 name: Hello World
 description: Greets you by name!
+slug: hello_world
 
 image: alpine:3
 command: ["echo"]

--- a/node/hello-world-javascript/airplane.yml
+++ b/node/hello-world-javascript/airplane.yml
@@ -1,5 +1,6 @@
 name: Hello World
 description: Greets you by name!
+slug: hello_world
 
 builder: node
 builderConfig:

--- a/node/hello-world-typescript/airplane.yml
+++ b/node/hello-world-typescript/airplane.yml
@@ -1,5 +1,6 @@
 name: Hello World
 description: Greets you by name!
+slug: hello_world
 
 builder: node
 builderConfig:

--- a/python/hello-world/airplane.yml
+++ b/python/hello-world/airplane.yml
@@ -1,5 +1,6 @@
 name: Hello World
 description: Greets you by name!
+slug: hello_world
 
 builder: python
 builderConfig:


### PR DESCRIPTION
Now that the `init` command creates slugs and deploy expects a `slug` field to be set, we will need to pre-configure slugs for all of our examples. However, that works out well since that means all our examples are now valid rather than relying on our CLI to add a slug for you.

In a future CLI PR though, we'll need to add logic to the `deploy` command to check if the slug is unique and ask if the user wants to create a new task with a different slug.