### PR TITLE
Use config in Go Run SQL task

### DIFF
--- a/go/sql/airplane.yml
+++ b/go/sql/airplane.yml
@@ -10,6 +10,11 @@ env:
   AIRPLANE_DRIVER:
     value: postgres
   AIRPLANE_DSN:
+    # When you deploy this task for the first time, the CLI will prompt you
+    # through creating a config variable called `db/dsn` to store your
+    # database's DSN.
+    #
+    # If you already have a config variable for this then update the name below.
     config: db/dsn
 
 arguments: ["{{.JSON}}"]

--- a/go/sql/airplane.yml
+++ b/go/sql/airplane.yml
@@ -10,12 +10,7 @@ env:
   AIRPLANE_DRIVER:
     value: postgres
   AIRPLANE_DSN:
-    # TODO(you): add your DSN as a secret Airplane config variable: https://docs.airplane.dev/reference/configs
-    #
-    # config: db/dsn
-    #
-    # For testing, you can alternatively directly provide your DSN below:
-    value: TODO
+    config: db/dsn
 
 arguments: ["{{.JSON}}"]
 parameters:


### PR DESCRIPTION
This PR updates the `Run SQL` task to utilize the CLI's new behavior for auto-prompting about the creation of configs.