### PR TITLE
Add no_requirements python sample

### DIFF
--- a/python/no_requirements/airplane.yml
+++ b/python/no_requirements/airplane.yml
@@ -1,0 +1,14 @@
+name: Hello World
+description: Greets you by name!
+slug: hello_world_no_reqs
+
+builder: python
+builderConfig:
+  entrypoint: main.py
+
+arguments: ["--name", "{{.name}}"]
+parameters:
+  - name: Name
+    slug: name
+    type: string
+    default: World

--- a/python/no_requirements/main.py
+++ b/python/no_requirements/main.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import sys
+
+def main(args):
+    print("args:", args)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
Used to test the CLI's recent changes, previously the builders (remote & local)
required the `requirements.txt` file, the new patch ensures that a `reuqirements.txt`
is created when missing.